### PR TITLE
Lift SpeziLLM dependency to v0.7

### DIFF
--- a/Stronger.xcodeproj/project.pbxproj
+++ b/Stronger.xcodeproj/project.pbxproj
@@ -469,7 +469,6 @@
 		7DE98D7E2B69D90400449C81 /* Workout */ = {
 			isa = PBXGroup;
 			children = (
-				38FE1D012B7169DF008F8BE0 /* WorkoutVideoView.swift */,
 				7DE98D802B69D96300449C81 /* InputForm.swift */,
 			);
 			path = Workout;
@@ -1293,7 +1292,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.2.1;
 			};
 		};
 		2FB099B42A875E2B00B20952 /* XCRemoteSwiftPackageReference "HealthKitOnFHIR" */ = {
@@ -1341,7 +1340,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziQuestionnaire.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.0.2;
 			};
 		};
 		2FE5DC8829EDD972004B9AB4 /* XCRemoteSwiftPackageReference "SpeziStorage" */ = {
@@ -1404,8 +1403,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziLLM.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.1;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.7.0;
 			};
 		};
 		97F466E62A76BBEE005DC9B4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
@@ -1413,7 +1412,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Stronger.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stronger.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI",
       "state" : {
-        "revision" : "ac5892fd0de8d283362ddc30f8e9f1a0eaba8cc0",
-        "version" : "0.2.5"
+        "revision" : "35afc9a6ee127b8f22a85a31aec2036a987478af",
+        "version" : "0.2.6"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
-        "version" : "2.3.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKit",
       "state" : {
-        "revision" : "66f2fca769dc103de5801bb491b1d8ceafcd281e",
-        "version" : "2.2.23"
+        "revision" : "15f06cf7c1d2d22805b7b939823536bc78ad63a6",
+        "version" : "2.2.25"
       }
     },
     {
@@ -158,8 +158,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKitOnFHIR",
       "state" : {
-        "revision" : "ea4d9691591594177e7dfbc8c246324855d73eb5",
-        "version" : "1.0.1"
+        "revision" : "300fbc0038df28f53a9b653298931f71aa6f0bb5",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore.git",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
       }
     },
     {
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "c4bf0e99de40acfdd2baf0fa02769f06a4c3f0eb",
-        "version" : "1.1.0"
+        "revision" : "0ced3efbc2af9513c07ac913ad762c773a00a6c8",
+        "version" : "1.2.1"
       }
     },
     {
@@ -176,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "714f01ae1e67bf9c1c0e7c07624380f9bea772b7",
-        "version" : "1.1.0"
+        "revision" : "a7d289ef3be54de62b25dc92e8f7ff1a0f093906",
+        "version" : "1.2.1"
       }
     },
     {
@@ -185,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziChat",
       "state" : {
-        "revision" : "ea5e21b4f42d99a5549dd7a7033e2a3efeb5fd36",
-        "version" : "0.1.5"
+        "revision" : "eae5c15b211f18e09aa98de63ce119629320afeb",
+        "version" : "0.1.8"
       }
     },
     {
@@ -221,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "d882734a4ed31fce1bffd7b9977e2669080f21de",
-        "version" : "0.5.0"
+        "revision" : "b40695ffa4d1c9d58c5a0ee277640c2343fb5516",
+        "version" : "0.5.1"
       }
     },
     {
@@ -230,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziLLM.git",
       "state" : {
-        "revision" : "94c1f3bd3eb9412e3321a46730c1572da11bd951",
-        "version" : "0.6.1"
+        "revision" : "6892c5dfe258371b6f3287f02b8fec57a611ba70",
+        "version" : "0.7.0"
       }
     },
     {
@@ -248,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
       "state" : {
-        "revision" : "8fb6d9f1a080661c0cc564a93b82ead3c8d44d4f",
-        "version" : "1.0.2"
+        "revision" : "91463ae190611bd14ef52b0657e8db3bf53c9ae8",
+        "version" : "1.1.0"
       }
     },
     {
@@ -257,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziQuestionnaire.git",
       "state" : {
-        "revision" : "fac0bb02f7027b4c09bd7afdad55eb7b47ec67f3",
-        "version" : "1.0.1"
+        "revision" : "f25580e95bfdad02383980dcb94406cf97b08ea8",
+        "version" : "1.0.2"
       }
     },
     {
@@ -266,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziScheduler.git",
       "state" : {
-        "revision" : "adf793cb47dc199f8ae88f5c719f4d3ba06a4c4e",
-        "version" : "0.8.0"
+        "revision" : "ba391084109a9a16622b07e9dcefe2ab1552d2a2",
+        "version" : "0.8.1"
       }
     },
     {
@@ -275,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziSpeech",
       "state" : {
-        "revision" : "a1e1d021d8f605b5e6b23aee773115d7125a57e3",
-        "version" : "1.0.0"
+        "revision" : "60b8cdbf6f3d58b0d75eadf30db50f88848069aa",
+        "version" : "1.0.1"
       }
     },
     {
@@ -293,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
       "state" : {
-        "revision" : "7210f72d6821d2eeb93438b29cb854a8ce334164",
-        "version" : "1.2.0"
+        "revision" : "d49f716e4a4d634604bb0dcd6d53df679b6c1358",
+        "version" : "1.3.0"
       }
     },
     {
@@ -338,8 +347,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTestExtensions.git",
       "state" : {
-        "revision" : "fb7fcee97c574b950e03b0a53874e26db27db2fe",
-        "version" : "0.4.8"
+        "revision" : "1fe9b8e76aeb7a132af37bfa0892160c9b662dcc",
+        "version" : "0.4.10"
       }
     },
     {
@@ -356,8 +365,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTRuntimeAssertions",
       "state" : {
-        "revision" : "bb2a287c2544aa846e53670d1ece35e5949567be",
-        "version" : "1.0.0"
+        "revision" : "51da3403f128b120705571ce61e0fe190f8889e6",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/Stronger/ProteinTracker/ChatWindow.swift
+++ b/Stronger/ProteinTracker/ChatWindow.swift
@@ -78,9 +78,7 @@ struct LogProteinIntake: LLMFunction {
 
 
 struct ChatWindow: View {
-    @State var showOnboarding = true
-    
-    @State var model: LLMOpenAI = .init(
+    private static let llmSchema: LLMOpenAISchema = .init(
         parameters: .init(
             modelType: .gpt3_5Turbo,
             systemPrompt: """
@@ -107,17 +105,20 @@ struct ChatWindow: View {
         LogProteinIntake()
     }
     
+    @LLMSessionProvider(schema: Self.llmSchema) var session: LLMOpenAISession
+    @State var showOnboarding = true
+    
     var body: some View {
         NavigationStack {
             LLMChatView(
-                model: model
+                session: $session
             )
                 .navigationTitle("Pro-ChatBot")
                 .sheet(isPresented: $showOnboarding) {
                     LLMOnboardingView(showOnboarding: $showOnboarding)
                 }
                 .task {
-                    model.context.append(assistantOutput: "Hello! What did you have for your last meal?")
+                    session.context.append(assistantOutput: "Hello! What did you have for your last meal?")
                 }
         }
     }

--- a/Stronger/Resources/Localizable.xcstrings
+++ b/Stronger/Resources/Localizable.xcstrings
@@ -97,7 +97,13 @@
         }
       }
     },
+    "Comments" : {
+
+    },
     "Commonly Saved Items" : {
+
+    },
+    "Completed" : {
 
     },
     "COMPLETED_TASK_LABEL %@" : {
@@ -265,6 +271,9 @@
 
     },
     "How to Squat!" : {
+
+    },
+    "Incomplete" : {
 
     },
     "Input New Food to Chat" : {
@@ -540,9 +549,6 @@
 
     },
     "Select Saved Meal" : {
-
-    },
-    "Select Set" : {
 
     },
     "Set %lld" : {

--- a/Stronger/StrongerDelegate.swift
+++ b/Stronger/StrongerDelegate.swift
@@ -57,7 +57,7 @@ class StrongerDelegate: SpeziAppDelegate {
             OnboardingDataSource()
             
             LLMRunner {
-                LLMOpenAIRunnerSetupTask()
+                LLMOpenAIPlatform()
             }
         }
     }


### PR DESCRIPTION
# Lift SpeziLLM dependency to v0.7

## :recycle: Current situation & Problem
The Stronger app currently depends on SpeziLLM v0.6, which is outdated as of last week.
SpeziLLM v0.7 contains breaking API changes, therefore leading to compile errors within the project.


## :gear: Release Notes 
- Lift the SpeziLLM dependency to v0.7 and adjust to breaking API changes.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).